### PR TITLE
Add static typechecking to CI

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -9,6 +9,7 @@ If there is a request to add a tool to the package's installed-tools list, the t
 1. A unit test suite that exercises the tool's command line features, such as flags, and `pytest` tests to confirm expected output.
 2. A documentation page, preferably a README alongside the unit test suite.  The documentation should include command-line usage.
 3. A row in [`dfxml/bin/README.md`](dfxml/bin/README.md)'s table of installed tools, linking to the documentation.
+4. The tool should be analyzed with a static type checker.  See e.g. the target `check-mypy` in the [tests Makefile](tests/Makefile) that is run as part of CI.  (Note this would be started by adding type signatures to the tool's functions.)
 
 
 ## Version management

--- a/README.md
+++ b/README.md
@@ -62,3 +62,6 @@ The [DFXML schema](https://github.com/dfxml-working-group/dfxml_schema) is track
   - Removed calls to logging in Objects tests where the only thing that the test program was logging was the fact that it had run. py.test will provide similar logging now.
 
 --- Simson Garfinkel, May 6, 2021
+
+## Disclaimer
+Participation by NIST in the creation of the documentation of mentioned software is not intended to imply a recommendation or endorsement by the National Institute of Standards and Technology, nor is it intended to imply that any specific software is necessarily the best available for the purpose.

--- a/dfxml/__init__.py
+++ b/dfxml/__init__.py
@@ -884,9 +884,6 @@ class fileobject:
     def frag_start_sector(self,fragment):
         return self.byte_runs()[fragment].img_offset / 512
 
-    def name_type(self):
-        return self.tag("name_type")
-
 class fileobject_dom(fileobject):
     """file objects created through the DOM. Each object has the XML document
     stored in the .doc attribute."""    

--- a/dfxml/bin/allocation_counter.py
+++ b/dfxml/bin/allocation_counter.py
@@ -23,7 +23,7 @@ __version__ = "0.1.1"
 # * Tabular output in LaTeX
 
 import dfxml.objects as Objects
-import make_differential_dfxml
+import dfxml.bin.make_differential_dfxml
 
 import collections
 import logging
@@ -38,7 +38,7 @@ def main():
     prev_obj = None
     for (event, obj) in Objects.iterparse(args.input_image):
         if isinstance(obj, Objects.FileObject):
-            if args.ignore_virtual_files and make_differential_dfxml.ignorable_name(obj.filename):
+            if args.ignore_virtual_files and dfxml.bin.make_differential_dfxml.ignorable_name(obj.filename):
                 continue
             counter[(obj.alloc_inode, obj.alloc_name)] += 1
 

--- a/dfxml/bin/deidentify_xml.py
+++ b/dfxml/bin/deidentify_xml.py
@@ -6,6 +6,8 @@
 #
 # 2012-10-27 slg - updated to Python3
 
+import typing
+
 private_dirs = ["home/","usr/home","Users"]
 ok_top_paths_win = ["program files/","System","Windows"]
 ok_top_paths_mac = ["bin/","usr","etc","private","applications","developer",'bin','sbin','lib','dev']
@@ -14,7 +16,7 @@ acceptable_extensions = ["exe","dll","sys","com","hlp"]
 
 import os.path, os, sys
 
-partdir = {}
+partdir : typing.Dict[str, str] = dict()
 def sanitize_part(part):
     """Sanitize a part of a pathname in a consistent manner"""
     if part not in partdir:

--- a/dfxml/bin/filesdb.py
+++ b/dfxml/bin/filesdb.py
@@ -107,4 +107,4 @@ if __name__=="__main__":
     db   = filesdb()
     for fn in args.xmlfiles:
         db.read(fn)
-    print(db.stats())
+    db.print_stats()

--- a/dfxml/bin/icarvingtruth.py
+++ b/dfxml/bin/icarvingtruth.py
@@ -184,7 +184,7 @@ if __name__=="__main__":
                 if sectors_that_match:
                     if options.debug:
                         print(fi.filename(),
-                              "run sectors:", db.sectors_for_bytes(run_len),
+                              "run sectors:", db.sectors_for_bytes(run.len),
                               "total sectors: ",len(sectors_to_check),
                               "matching:",len(sectors_that_match))
                     runs = db.runs_for_sectors(sectors_that_match)

--- a/dfxml/bin/imap.py
+++ b/dfxml/bin/imap.py
@@ -24,7 +24,8 @@ if __name__=="__main__":
 
     imagefile = open(args[0],"r")
     annotated_runs = []
-    if options.debug: print("Read %d file objects from %s" % (len(fileobjects),imagefile.name))
+    #TODO - This debug statement needs to moved to somewhere appropriate after an image read.
+    #if options.debug: print("Read %d file objects from %s" % (len(fileobjects),imagefile.name))
 
     def cb(fi):
         if options.debug: print("Read "+str(fi))

--- a/dfxml/bin/imicrosoft_redact.py
+++ b/dfxml/bin/imicrosoft_redact.py
@@ -123,7 +123,7 @@ if __name__=="__main__":
         fns = args
 
     for fn in fns:
-        print "Redacting %s" % fn
+        print("Redacting %s" % fn)
         xml_out = open(fn.replace(".raw","-redacted.xml"),"w")
         xml_out.write("<?xml version='1.0' encoding='ISO-8859-1'?>\n")
         xml_out.write("<redaction_report>\n")

--- a/dfxml/bin/make_differential_dfxml.py
+++ b/dfxml/bin/make_differential_dfxml.py
@@ -22,7 +22,7 @@ Produces a differential DFXML file as output.
 This program's main purpose is matching files correctly.  It only performs enough analysis to determine that a fileobject has changed at all.  (This is half of the work done by idifference.py.)
 """
 
-__version__ = "0.12.2"
+__version__ = "0.12.3"
 
 import argparse
 import collections

--- a/dfxml/bin/make_differential_dfxml.py
+++ b/dfxml/bin/make_differential_dfxml.py
@@ -29,6 +29,7 @@ import collections
 import logging
 import os
 import sys
+import typing
 import xml.etree.ElementTree as ET
 
 import dfxml
@@ -36,45 +37,56 @@ import dfxml.objects as Objects
 
 _logger = logging.getLogger(os.path.basename(__file__))
 
-def _lower_ftype_str(vo):
-    """The string labels of file system names might differ by something small like the casing.  Normalize the labels by lower-casing them."""
+def _lower_ftype_str(
+  vo : Objects.VolumeObject
+) -> str:
+    """
+    The string labels of file system names might differ by something small like the casing.  Normalize the labels by lower-casing them.
+
+    Note that this does not mutate the input vo.
+    """
     Objects._typecheck(vo, Objects.VolumeObject)
     f = vo.ftype_str
     if isinstance(f, str): f = f.lower()
     return f
 
-def ignorable_name(fn):
+def ignorable_name(
+  fn : str
+) -> bool:
     """Filter out recognized pseudo-file names."""
     if fn is None:
         return False
     return os.path.basename(fn) in [".", "..", "$FAT1", "$FAT2", "$OrphanFiles"]
 
-def make_differential_dfxml(pre, post, **kwargs):
+def make_differential_dfxml(
+  pre : str,
+  post : str,
+  *,
+  annotate_matches : bool = False,
+  diff_mode : str = "all",
+  glom_byte_runs : bool = False,
+  ignore_filename_function : typing.Callable[[str], bool] = ignorable_name,
+  rename_requires_hash : bool = False,
+  retain_unchanged : bool = False,
+  ignore_properties : typing.Set[str] = set()
+) -> Objects.DFXMLObject:
     """
     Takes as input two paths to DFXML files.  Returns a DFXMLObject.
-    @param pre String.
-    @param post String.
-    @param diff_mode Optional.  One of "all" or "idifference".
-    @param retain_unchanged Optional.  Boolean.
-    @param ignore_properties Optional.  Set.
-    @param annotate_matches Optional.  Boolean.  True -> matched file objects get a "delta:matched='1'" attribute.
-    @param rename_requires_hash Optional.  Boolean.  True -> all matches require matching SHA-1's, if present.
-    @param ignore_filename_function Optional.  Function, string -> Boolean.  Returns True if a file name (which can be null) should be ignored.
-    @param glom_byte_runs Optional.  Boolean.  Joins contiguous-region byte runs together in FileObject byte run lists.
+    :param pre: Path to DFXML file containing baseline manifest.
+    :param post: Path to DFXML file containing second-impression manifest.
+    :param diff_mode: Optional.  One of "all" or "idifference".
+    :param retain_unchanged: Optional.  Boolean.
+    :param ignore_properties: Optional.  Set.
+    :param annotate_matches: Optional.  Boolean.  True -> matched file objects get a "delta:matched='1'" attribute.
+    :param rename_requires_hash: Optional.  Boolean.  True -> all matches require matching SHA-1's, if present.
+    :param ignore_filename_function: Optional.  Function, string -> Boolean.  Returns True if a file name (which can be null) should be ignored.
+    :param glom_byte_runs: Optional.  Boolean.  Joins contiguous-region byte runs together in FileObject byte run lists.
     """
 
-    diff_mode = kwargs.get("diff_mode", "all")
-    retain_unchanged = kwargs.get("retain_unchanged", False)
-    ignore_properties = kwargs.get("ignore_properties", set())
-    annotate_matches = kwargs.get("annotate_matches", False)
-    rename_requires_hash = kwargs.get("rename_requires_hash", False)
-    ignore_filename_function = kwargs.get("ignore_filename_function", ignorable_name)
-    glom_byte_runs = kwargs.get("glom_byte_runs", False)
-
-    _expected_diff_modes = ["all", "idifference"]
+    _expected_diff_modes = {"all", "idifference"}
     if diff_mode not in _expected_diff_modes:
         raise ValueError("Differencing mode should be in: %r." % _expected_diff_modes)
-    diff_mask_set = set()
+    diff_mask_set : typing.Set[str] = set()
 
     if diff_mode == "idifference":
         diff_mask_set |= set([
@@ -106,27 +118,30 @@ def make_differential_dfxml(pre, post, **kwargs):
     _logger.debug("d.diff_file_ignores = " + repr(d.diff_file_ignores))
 
     #The list most of this function is spent on building
-    fileobjects_changed = []
+    fileobjects_changed : typing.List[Objects.FileObject] = []
 
     #Unmodified files; only retained if requested.
-    fileobjects_unchanged = []
+    fileobjects_unchanged : typing.List[Objects.FileObject] = []
 
     #Key: (partition, inode, filename); value: FileObject
-    old_fis = None
-    new_fis = None
+    Signature_fis = typing.Dict[typing.Tuple[typing.Optional[int], typing.Optional[int], typing.Optional[str]], Objects.FileObject] 
+    old_fis : Signature_fis = dict()
+    new_fis : Signature_fis = dict()
 
     #Key: (partition, inode, filename); value: FileObject list
-    old_fis_unalloc = None
-    new_fis_unalloc = None
+    Signature_fis_unalloc = typing.Dict[typing.Tuple[typing.Optional[int], typing.Optional[int], typing.Optional[str]], typing.List[Objects.FileObject]]
+    old_fis_unalloc : Signature_fis_unalloc = dict()
+    new_fis_unalloc : Signature_fis_unalloc = dict()
 
     #Key: Partition byte offset within the disk image, paired with the file system type
     #Value: VolumeObject
-    old_volumes = None
-    new_volumes = None
-    matched_volumes = dict()
+    Signature_volumes = typing.Dict[typing.Tuple[int, str], Objects.VolumeObject] 
+    old_volumes : Signature_volumes = dict()
+    new_volumes : Signature_volumes = dict()
+    matched_volumes : Signature_volumes = dict()
 
     #Populated in distinct (offset, file system type as string) encounter order
-    volumes_encounter_order = dict()
+    volumes_encounter_order : typing.Dict[typing.Tuple[int, str], int] = dict()
 
     for infile in [pre, post]:
 
@@ -176,8 +191,8 @@ def make_differential_dfxml(pre, post, **kwargs):
                 #1. If the volume is in the old list, pop it out of the old list - it's matched.
                 if old_volumes and (offset, ftype_str) in old_volumes:
                     _logger.debug("Found a volume in post image, at offset %r." % offset)
-                    old_obj = old_volumes.pop((offset, ftype_str))
-                    new_obj.original_volume = old_obj
+                    old_vobj = old_volumes.pop((offset, ftype_str))
+                    new_obj.original_volume = old_vobj
                     new_obj.compare_to_original()
                     matched_volumes[(offset, ftype_str)] = new_obj
 
@@ -188,9 +203,6 @@ def make_differential_dfxml(pre, post, **kwargs):
                     volumes_encounter_order[(offset, ftype_str)] = len(new_volumes) + ((old_volumes and len(old_volumes)) or 0) + len(matched_volumes)
 
                 #3. Afterwards, the old list contains deleted volumes.
-
-                #Record the ID
-                new_obj.id = volumes_encounter_order[(offset, ftype_str)]
 
                 #Move on to the next object
                 continue
@@ -229,15 +241,15 @@ def make_differential_dfxml(pre, post, **kwargs):
                 continue
 
             #The rest of this loop is irrelevant until the second DFXML file.
-            if old_fis is None:
+            if infile == pre:
                 new_fis[key] = new_obj
                 continue
 
 
             if key in old_fis:
                 #Extract the old fileobject and check for changes
-                old_obj = old_fis.pop(key)
-                new_obj.original_fileobject = old_obj
+                old_fobj = old_fis.pop(key)
+                new_obj.original_fileobject = old_fobj
                 new_obj.compare_to_original(file_ignores=d.diff_file_ignores)
 
                 #_logger.debug("Diffs: %r." % _diffs)
@@ -259,7 +271,7 @@ def make_differential_dfxml(pre, post, **kwargs):
                 new_fis[key] = new_obj
 
         #The rest of the files loop is irrelevant until the second file.
-        if old_fis is None:
+        if infile == pre:
             continue
 
 
@@ -272,7 +284,15 @@ def make_differential_dfxml(pre, post, **kwargs):
         #Identify renames - only possible if 1-to-1.  Many-to-many renames are just left as new and deleted files.
         _logger.debug("Detecting renames...")
         fileobjects_renamed = []
-        def _make_name_map(d):
+        def _make_name_map(
+          d : Signature_fis
+        ) -> typing.Dict[
+          typing.Tuple[
+            typing.Optional[int],
+            typing.Optional[int]
+          ],
+          typing.Set[typing.Optional[str]]
+        ]:
             """Returns a dictionary, mapping (partition, inode) -> {filename}."""
             retdict = collections.defaultdict(lambda: set())
             for (partition, inode, filename) in d.keys():
@@ -280,28 +300,28 @@ def make_differential_dfxml(pre, post, **kwargs):
             return retdict
         old_inode_names = _make_name_map(old_fis)
         new_inode_names = _make_name_map(new_fis)
-        for key in new_inode_names.keys():
-            (partition, inode) = key
+        for new_inode_name_key in new_inode_names.keys():
+            (partition, inode) = new_inode_name_key
 
-            if len(new_inode_names[key]) != 1:
+            if len(new_inode_names[new_inode_name_key]) != 1:
                 continue
-            if not key in old_inode_names:
+            if not new_inode_name_key in old_inode_names:
                 continue
-            if len(old_inode_names[key]) != 1:
+            if len(old_inode_names[new_inode_name_key]) != 1:
                 continue
             if rename_requires_hash:
                 #Peek at the set elements by doing a quite-ephemeral list cast
-                old_obj = old_fis[(partition, inode, list(old_inode_names[key])[0])]
-                new_obj = new_fis[(partition, inode, list(new_inode_names[key])[0])]
-                if old_obj.sha1 != new_obj.sha1:
+                old_fobj = old_fis[(partition, inode, list(old_inode_names[new_inode_name_key])[0])]
+                new_obj = new_fis[(partition, inode, list(new_inode_names[new_inode_name_key])[0])]
+                if old_fobj.sha1 != new_obj.sha1:
                     continue
 
             #Found a match if we're at this point in the loop
-            old_name = old_inode_names[key].pop()
-            new_name = new_inode_names[key].pop()
-            old_obj = old_fis.pop((partition, inode, old_name))
+            old_name = old_inode_names[new_inode_name_key].pop()
+            new_name = new_inode_names[new_inode_name_key].pop()
+            old_fobj = old_fis.pop((partition, inode, old_name))
             new_obj = new_fis.pop((partition, inode, new_name))
-            new_obj.original_fileobject = old_obj
+            new_obj.original_fileobject = old_fobj
             new_obj.compare_to_original(file_ignores=d.diff_file_ignores)
             fileobjects_renamed.append(new_obj)
         _logger.debug("len(old_fis) -> %d" % len(old_fis))
@@ -311,7 +331,15 @@ def make_differential_dfxml(pre, post, **kwargs):
 
         #Identify files that just changed inode number - basically, doing the rename detection again
         _logger.debug("Detecting inode number changes...")
-        def _make_inode_map(d):
+        def _make_inode_map(
+          d : Signature_fis
+        ) -> typing.Dict[
+          typing.Tuple[
+            typing.Optional[int],
+            typing.Optional[str]
+          ],
+          typing.Optional[int]
+        ]:
             """Returns a dictionary, mapping (partition, filename) -> inode."""
             retdict = dict()
             for (partition, inode, filename) in d.keys():
@@ -321,13 +349,13 @@ def make_differential_dfxml(pre, post, **kwargs):
             return retdict
         old_name_inodes = _make_inode_map(old_fis)
         new_name_inodes = _make_inode_map(new_fis)
-        for key in new_name_inodes.keys():
-            if not key in old_name_inodes:
+        for name_inode_key in new_name_inodes.keys():
+            if not name_inode_key in old_name_inodes:
                 continue
-            (partition, name) = key
-            old_obj = old_fis.pop((partition, old_name_inodes[key], name))
-            new_obj = new_fis.pop((partition, new_name_inodes[key], name))
-            new_obj.original_fileobject = old_obj
+            (partition, name) = name_inode_key
+            old_fobj = old_fis.pop((partition, old_name_inodes[name_inode_key], name))
+            new_obj = new_fis.pop((partition, new_name_inodes[name_inode_key], name))
+            new_obj.original_fileobject = old_fobj
             #TODO Test for what chaos ensues when filename is in the ignore list.
             new_obj.compare_to_original(file_ignores=d.diff_file_ignores)
             fileobjects_changed.append(new_obj)
@@ -347,9 +375,9 @@ def make_differential_dfxml(pre, post, **kwargs):
             if key in old_fis_unalloc:
                 if len(old_fis_unalloc[key]) == 1:
                     #The file was unallocated in the previous image, too.
-                    old_obj = old_fis_unalloc[key].pop()
+                    old_fobj = old_fis_unalloc[key].pop()
                     new_obj = new_fis_unalloc[key].pop()
-                    new_obj.original_fileobject = old_obj
+                    new_obj.original_fileobject = old_fobj
                     new_obj.compare_to_original(file_ignores=d.diff_file_ignores)
                     #The file might not have changed.  It's interesting if it did, though.
 
@@ -365,9 +393,9 @@ def make_differential_dfxml(pre, post, **kwargs):
                         fileobjects_unchanged.append(new_obj)
             elif key in old_fis:
                 #Identified a deletion.
-                old_obj = old_fis.pop(key)
+                old_fobj = old_fis.pop(key)
                 new_obj = new_fis_unalloc[key].pop()
-                new_obj.original_fileobject = old_obj
+                new_obj.original_fileobject = old_fobj
                 new_obj.compare_to_original(file_ignores=d.diff_file_ignores)
                 fileobjects_deleted.append(new_obj)
         _logger.debug("len(old_fis) -> %d" % len(old_fis))
@@ -385,21 +413,24 @@ def make_differential_dfxml(pre, post, **kwargs):
 
         #Begin output.
         #First, annotate the volume objects.
-        for key in new_volumes:
-            v = new_volumes[key]
+        for nv_key in new_volumes:
+            v = new_volumes[nv_key]
             v.annos.add("new")
-        for key in old_volumes:
-            v = old_volumes[key]
+        for ov_key in old_volumes:
+            v = old_volumes[ov_key]
             v.annos.add("deleted")
-        for key in matched_volumes:
-            v = matched_volumes[key]
+        for mv_key in matched_volumes:
+            v = matched_volumes[mv_key]
             if len(v.diffs) > 0:
                 v.annos.add("modified")
 
         #Build list of FileObject appenders, child volumes of the DFXML Document.
         #Key: Partition number, or None
         #Value: Reference to the VolumeObject corresponding with that partition number.  None -> the DFXMLObject.
-        appenders = dict()
+        appenders : typing.Dict[
+          typing.Optional[int],
+          typing.Union[Objects.DFXMLObject, Objects.VolumeObject]
+        ] = dict()
         for volume_dict in [new_volumes, matched_volumes, old_volumes]:
             for (offset, ftype_str) in volume_dict:
                     veo = volumes_encounter_order[(offset, ftype_str)]
@@ -474,10 +505,10 @@ def make_differential_dfxml(pre, post, **kwargs):
             _maybe_match_attr(fi)
             appenders[fi.partition].append(fi)
 
-        #Output
-        return d
+    #Output
+    return d
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("-d", "--debug", action="store_true")
     parser.add_argument("--idifference-diffs", action="store_true", help="Only consider the modifications idifference had considered (names, hashes, timestamps).")
@@ -498,9 +529,6 @@ def main():
     if len(args.infiles) != 2:
         raise ValueError("This script requires exactly two DFXML files as input.")
 
-    pre = None
-    post = None
-
     if len(args.infiles) > 2:
         raise NotImplementedError("This program only analyzes two files at the moment.")
 
@@ -509,20 +537,22 @@ def main():
         for i in args.ignore:
             ignore_properties.add(i)
 
-    for infile in args.infiles:
+    post : str = args.infiles[0]
+
+    for infile in args.infiles[1:]:
         pre = post
         post = infile
-        if not pre is None:
-            dobj = make_differential_dfxml(
-              pre,
-              post,
-              diff_mode="idifference" if args.idifference_diffs else "all",
-              retain_unchanged=args.retain_unchanged,
-              ignore_properties=ignore_properties,
-              annotate_matches=args.annotate_matches,
-              rename_requires_hash=args.rename_with_hash
-            )
-            dobj.print_dfxml()
+        dobj = make_differential_dfxml(
+          pre,
+          post,
+          diff_mode="idifference" if args.idifference_diffs else "all",
+          retain_unchanged=args.retain_unchanged,
+          ignore_properties=ignore_properties,
+          annotate_matches=args.annotate_matches,
+          rename_requires_hash=args.rename_with_hash
+        )
+        #TODO - Some more thought needs to be put into whether this program should analyze more than two files.
+        dobj.print_dfxml()
 
 if __name__ == "__main__":
     main()

--- a/dfxml/bin/walk_to_dfxml.py
+++ b/dfxml/bin/walk_to_dfxml.py
@@ -21,18 +21,19 @@ Walk current directory, writing DFXML to stdout.
 
 __version__ = "0.4.2"
 
-import os
-import stat
-import hashlib
-import traceback
-import logging
-import sys
+import argparse
 import collections
 import functools
-
-_logger = logging.getLogger(os.path.basename(__file__))
+import hashlib
+import logging
+import os
+import stat
+import sys
+import traceback
 
 import dfxml.objects as Objects
+
+_logger = logging.getLogger(os.path.basename(__file__))
 
 #Exclude md6 from hash list borrowed from Objects.py - hashlib doesn't support md6.
 walk_default_hashes = Objects.FileObject._hash_properties - {"md6"}
@@ -172,7 +173,6 @@ def filepath_to_fileobject(filepath, **kwargs):
 def main():
     global walk_default_hashes
 
-    import argparse
     parser = argparse.ArgumentParser()
     parser.add_argument("-d", "--debug", action="store_true")
     parser.add_argument("-i", "--ignore", action="append", help="Do not track named property on file objects.  E.g. '-i inode' will exclude inode numbers from DFXML manifest.  Can be given multiple times.  To exclude a fileobject property of a specific file type (e.g. regular, directory, device), supply the name_type value in addition; for example, to ignore mtime of a directory, '-i mtime@d'.")

--- a/dfxml/bin/walk_to_dfxml.py
+++ b/dfxml/bin/walk_to_dfxml.py
@@ -19,7 +19,7 @@ walk_to_dfxml
 Walk current directory, writing DFXML to stdout.
 """
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 import argparse
 import collections

--- a/dfxml/objects.py
+++ b/dfxml/objects.py
@@ -39,11 +39,12 @@ import os
 import sys
 import struct
 import platform
+import typing
 
 # The following allows us to import the dfxml module as dfxml
 # There may be a cleaner way to do this.
 sys.path.append( os.path.dirname(__file__) + "/..")
-import dfxml
+import dfxml  # type: ignore
 
 
 _logger = logging.getLogger(os.path.basename(__file__))
@@ -312,7 +313,10 @@ class DFXMLObject(object):
                 # Put all non-DFXML-namespace elements into the externals list.
                 self.externals.append(ce)
 
-    def print_dfxml(self, output_fh=sys.stdout):
+    def print_dfxml(
+      self,
+      output_fh : typing.IO[str] = sys.stdout
+    ) -> None:
         """Memory-efficient DFXML document printer.  However, it assumes the whole element tree is already constructed."""
         pe = self.to_partial_Element()
         dfxml_wrapper = _ET_tostring(pe)

--- a/dfxml/objects.py
+++ b/dfxml/objects.py
@@ -2287,7 +2287,7 @@ class ByteRun(object):
       "uncompressed_len"
     ])
 
-    _hash_properties = set([
+    _hash_properties : typing.Set[str] = set([
       "md5",
       "sha1",
       "sha224",
@@ -3795,6 +3795,21 @@ class FileObject(object):
     @libmagic.setter
     def libmagic(self, val):
         self._libmagic = _strcast(val)
+
+    @property
+    def link_target(
+      self
+    ) -> typing.Optional[str]:
+        return self._link_target
+
+    @link_target.setter
+    def link_target(
+      self,
+      val : typing.Optional[str]
+    ) -> None:
+        if not val is None:
+            _typecheck(val, str)
+        self._link_target = val
 
     @property
     def inode_brs(self):

--- a/dfxml/objects.py
+++ b/dfxml/objects.py
@@ -18,7 +18,7 @@ This file re-creates the major DFXML classes with an emphasis on type safety, se
 With this module, reading disk images or DFXML files is done with the parse or iterparse functions.  Writing DFXML files can be done with the DFXMLObject.print_dfxml function.
 """
 
-__version__ = "0.11.1"
+__version__ = "0.11.2"
 
 # Revision Log
 # 2018-07-22 @simsong - removed calls to logging, since this module shouldn't create log files.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -76,6 +76,7 @@ check: \
 check-mypy:
 	source venv/bin/activate \
 	  && mypy \
+	    ../dfxml/bin/make_differential_dfxml.py \
 	    ../dfxml/bin/walk_to_dfxml.py \
 	    ../dfxml/__init__.py \
 	    ../dfxml/objects.py \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -29,7 +29,8 @@ all: \
 
 .PHONY: \
   all-make_differential_dfxml \
-  all-walk_to_dfxml
+  all-walk_to_dfxml \
+  check-mypy
 
 all-make_differential_dfxml: \
   .venv.done.log
@@ -65,10 +66,20 @@ all-walk_to_dfxml: \
 
 check: \
   all-make_differential_dfxml \
-  all-walk_to_dfxml
+  all-walk_to_dfxml \
+  check-mypy
 	source venv/bin/activate \
 	  && pytest \
 	    --log-level=DEBUG
+
+#TODO - Type-checking would best be done against all of ../dfxml, when someone finds some time to do so.
+check-mypy:
+	source venv/bin/activate \
+	  && mypy \
+	    ../dfxml/__init__.py \
+	    ../dfxml/objects.py \
+	    .
+	@echo "INFO:tests/Makefile:mypy is currently run against a subset of the dfxml directory." >&2
 
 clean:
 	@$(MAKE) \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -76,6 +76,7 @@ check: \
 check-mypy:
 	source venv/bin/activate \
 	  && mypy \
+	    ../dfxml/bin/walk_to_dfxml.py \
 	    ../dfxml/__init__.py \
 	    ../dfxml/objects.py \
 	    .

--- a/tests/make_differential_dfxml/test_differential_dfxml.py
+++ b/tests/make_differential_dfxml/test_differential_dfxml.py
@@ -37,6 +37,7 @@ import os
 import logging
 import sys
 import tempfile
+import typing
 
 import pytest
 
@@ -121,7 +122,7 @@ def ddo_23_from_module(samples_srcdir) -> Objects.DFXMLObject:
     return retval
 
 @pytest.fixture
-def ddo_23_from_serialization_1(ddo_23_from_module) -> Objects.DFXMLObject:
+def ddo_23_from_serialization_1(ddo_23_from_module) -> typing.Generator[Objects.DFXMLObject, None, None]:
     filename = None
     with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".dfxml") as tmp_fh:
         filename = tmp_fh.name
@@ -138,7 +139,7 @@ def ddo_23_from_serialization_1(ddo_23_from_module) -> Objects.DFXMLObject:
     #os.unlink(filename)
 
 @pytest.fixture
-def ddo_23_from_serialization_2(ddo_23_from_serialization_1) -> Objects.DFXMLObject:
+def ddo_23_from_serialization_2(ddo_23_from_serialization_1) -> typing.Generator[Objects.DFXMLObject, None, None]:
     filename = None
     with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".dfxml") as tmp_fh:
         filename = tmp_fh.name

--- a/tests/make_differential_dfxml/test_differential_dfxml.py
+++ b/tests/make_differential_dfxml/test_differential_dfxml.py
@@ -30,7 +30,7 @@ This pattern breaks down to:
 The rounds of serialization are to affirm losslessness.
 """
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 import argparse
 import os

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,1 +1,2 @@
+mypy
 pytest

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to title 17 Section 105 of the
+# United States Code this software is not subject to copyright
+# protection and is in the public domain. NIST assumes no
+# responsibility whatsoever for its use by other parties, and makes
+# no guarantees, expressed or implied, about its quality,
+# reliability, or any other characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+import logging
+import tempfile
+
+import pytest
+
+import dfxml.objects as Objects
+
+@pytest.mark.xfail(strict=True, reason="print_dfxml currently requires a text, not binary, writer.")
+def test_serialization_to_binary_file() -> None:
+    dobj = Objects.DFXMLObject()
+    with tempfile.NamedTemporaryFile(mode="w+b", suffix=".dfxml") as temp_fh:
+        logging.debug("temp_fh.name = %r.", temp_fh.name)
+        dobj.print_dfxml(temp_fh)  # type: ignore
+
+def test_serialization_to_text_file() -> None:
+    dobj = Objects.DFXMLObject()
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".dfxml") as temp_fh:
+        logging.debug("temp_fh.name = %r.", temp_fh.name)
+        dobj.print_dfxml(temp_fh)


### PR DESCRIPTION
This came about because I ran into a bytes-vs-characters runtime issue in `DFXMLObject.print_dfxml` (more fully described in commit 0157ce5c927980034bcc373a459c6abbc6b6b76b).

This patch starts to add type signatures and static type checking to the code base.  It is, for now, a needs-driven effort: Any tool under `dfxml/bin` that is to be promoted to a command-line tool is now encouraged by `CONTRIBUTE.md` to add type signatures, which should trickle into adding signatures where they're needed in the core library files (e.g. `dfxml/__init__.py`, `dfxml/objects.py`).