### PR TITLE
Ignore build/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ python/demo.dfxml
 schema
 
 .DS_Store
+build
 python/demo.dfxml
 .cache
 .pytest_cache


### PR DESCRIPTION
If this repository is tracked as a Git submodule, and then installed
from source with `pip install .../dfxml`, a `build/` directory is
generated.  It's not currently ignored, so the submodule is reported as
dirty to the superproject.  We should ignore `build/`.

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>