### PR TITLE
Check tools with mypy --strict

### DIFF
--- a/dfxml/bin/walk_to_dfxml.py
+++ b/dfxml/bin/walk_to_dfxml.py
@@ -32,6 +32,7 @@ import sys
 import traceback
 import typing
 
+import dfxml
 import dfxml.objects as Objects
 
 _logger = logging.getLogger(os.path.basename(__file__))
@@ -218,7 +219,7 @@ def main() -> None:
     dobj.dc["type"] = "File system walk"
     dobj.add_creator_library("Python", ".".join(map(str, sys.version_info[0:3]))) #A bit of a bend, but gets the major version information out.
     dobj.add_creator_library("Objects.py", Objects.__version__)
-    dobj.add_creator_library("dfxml.py", Objects.dfxml.__version__)
+    dobj.add_creator_library("dfxml.py", dfxml.__version__)
 
     # Key: property.
     # Value: set of name_types that should have the property ignored.  "*" indicates all.  No sets should be empty by the end of this setup.
@@ -253,10 +254,10 @@ def main() -> None:
 
     if using_threading:
         #Threading syntax c/o: https://docs.python.org/3.5/library/queue.html
-        q : queue.Queue = queue.Queue()
+        q : queue.Queue[typing.Optional[str]] = queue.Queue()
         threads = []
 
-        def _worker():
+        def _worker() -> None:
             while True:
                 filepath = q.get()
                 if filepath is None:

--- a/dfxml/objects.py
+++ b/dfxml/objects.py
@@ -3180,7 +3180,7 @@ class FileObject(AbstractObject):
         return "FileObject(" + ", ".join(parts) + ")"
 
     @staticmethod
-    def _should_ignore_property(ignore_properties, name_type, property_name):
+    def _should_ignore_property(ignore_properties, name_type, property_name) -> bool:
         """
         Helper function for FileObject.populate_from_stat and walk_to_dfxml.py.  Defined as class method instead of inline definition in heavily looped functions.
         """
@@ -3389,7 +3389,11 @@ class FileObject(AbstractObject):
                     _warned_elements.add((cns, ctn, FileObject))
                     _logger.warning("Uncertain what to do with this element in a FileObject: %r" % ce)
 
-    def populate_from_stat(self, s, **kwargs):
+    def populate_from_stat(
+      self,
+      s : os.stat_result,
+      **kwargs
+    ) -> None:
         """
         Populates FileObject fields from a stat() call.
         Optional arguments:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -30,7 +30,8 @@ all: \
 .PHONY: \
   all-make_differential_dfxml \
   all-walk_to_dfxml \
-  check-mypy
+  check-mypy \
+  check-mypy-strict
 
 all-make_differential_dfxml: \
   .venv.done.log
@@ -74,7 +75,7 @@ check: \
 
 #TODO - Type-checking would best be done against all of ../dfxml, when someone finds some time to do so.
 check-mypy: \
-  .venv.done.log
+  check-mypy-strict
 	source venv/bin/activate \
 	  && mypy \
 	    ../dfxml/bin/idifference.py \
@@ -82,12 +83,18 @@ check-mypy: \
 	    ../dfxml/bin/make_differential_dfxml.py \
 	    ../dfxml/bin/summarize_differential_dfxml.py \
 	    ../dfxml/bin/tests \
-	    ../dfxml/bin/walk_to_dfxml.py \
 	    ../dfxml/__init__.py \
 	    ../dfxml/objects.py \
 	    ../dfxml/tests \
 	    .
 	@echo "INFO:tests/Makefile:mypy is currently run against a subset of the dfxml directory." >&2
+
+check-mypy-strict: \
+  .venv.done.log
+	source venv/bin/activate \
+	  && mypy \
+	    --strict \
+	    ../dfxml/bin/walk_to_dfxml.py
 
 clean:
 	@$(MAKE) \


### PR DESCRIPTION
This patch series implements changes necessary to get command line tools (and idifference2) to pass the `--strict` mode of `mypy`.