### PR TITLE
Add type-safety checks to Objects.parse(), adding additional abstract classes

### DIFF
--- a/dfxml/__init__.py
+++ b/dfxml/__init__.py
@@ -1470,7 +1470,7 @@ class extentdb:
         return filter(lambda x:not self.intersects_sector(x),self.sectors_for_run(run))
 
 
-def read_dfxml(xmlfile=None,imagefile=None,flags=0,callback=None,preserve_fis=False):
+def read_dfxml(xmlfile=None,imagefile=None,flags=0,callback=None,preserve_fis=False) -> fileobject_reader:
     """Processes an image using expat, calling a callback for every file object encountered.
     If xmlfile is provided, use that as the xmlfile, otherwise runs fiwalk."""
     if not callback:

--- a/dfxml/objects.py
+++ b/dfxml/objects.py
@@ -1433,16 +1433,16 @@ class DiskImageObject(AbstractObject):
                 parts.append("%s=%s" % (prop, val))
         return "DiskImageObject(" + ", ".join(parts) + ")"
 
-    def append(self, obj) -> None:
-        if isinstance(obj, PartitionSystemObject):
-            self.partition_systems.append(obj)
-        elif isinstance(obj, VolumeObject):
-            self.volumes.append(obj)
-        elif isinstance(obj, FileObject):
-            self.files.append(obj)
+    def append(self, value) -> None:
+        if isinstance(value, PartitionSystemObject):
+            self.partition_systems.append(value)
+        elif isinstance(value, VolumeObject):
+            self.volumes.append(value)
+        elif isinstance(value, FileObject):
+            self.files.append(value)
         else:
-            raise ValueError("Unexpected object type passed to DiskImageObject.append(): %r." % type(obj))
-        self.child_objects.append(obj)
+            raise ValueError("Unexpected object type passed to DiskImageObject.append(): %r." % type(value))
+        self.child_objects.append(value)
 
     def pop_poststream_elements(self, diskimage_element):
         """
@@ -1696,19 +1696,19 @@ class PartitionSystemObject(AbstractObject):
                 parts.append("%s=%s" % (prop, val))
         return "PartitionSystemObject(" + ", ".join(parts) + ")"
 
-    def append(self, obj) -> None:
+    def append(self, value) -> None:
         """
         Note that files appended directly to a PartitionSystemObject are expected to be slack space discoveries.  A warning is raised if an allocated file is appended.
         """
-        if isinstance(obj, PartitionObject):
-            self.partitions.append(obj)
-        elif isinstance(obj, FileObject):
-            if obj.is_allocated():
+        if isinstance(value, PartitionObject):
+            self.partitions.append(value)
+        elif isinstance(value, FileObject):
+            if value.is_allocated():
                 warnings.warn("A partition system has had an 'allocated' file appended directly to it.  This list of files is expected to be slack space discoveries.")
-            self.files.append(obj)
+            self.files.append(value)
         else:
-            raise ValueError("Unexpected object type passed to PartitionSystemObject.append(): %r." % type(obj))
-        self.child_objects.append(obj)
+            raise ValueError("Unexpected object type passed to PartitionSystemObject.append(): %r." % type(value))
+        self.child_objects.append(value)
 
     def populate_from_Element(self, e):
         global _warned_elements
@@ -1998,23 +1998,23 @@ class PartitionObject(AbstractObject):
                 parts.append("%s=%s" % (prop, val))
         return "PartitionObject(" + ", ".join(parts) + ")"
 
-    def append(self, obj) -> None:
+    def append(self, value) -> None:
         """
         Note that files appended directly to a PartitionObject are expected to be slack space discoveries.  A warning is raised if an allocated file is appended.
         """
-        if isinstance(obj, PartitionSystemObject):
-            self.partition_systems.append(obj)
-        elif isinstance(obj, PartitionObject):
-            self.partitions.append(obj)
-        elif isinstance(obj, VolumeObject):
-            self.volumes.append(obj)
-        elif isinstance(obj, FileObject):
-            if obj.is_allocated():
+        if isinstance(value, PartitionSystemObject):
+            self.partition_systems.append(value)
+        elif isinstance(value, PartitionObject):
+            self.partitions.append(value)
+        elif isinstance(value, VolumeObject):
+            self.volumes.append(value)
+        elif isinstance(value, FileObject):
+            if value.is_allocated():
                 warnings.warn("A partition has had an 'allocated' file appended directly to it.  This list of files is expected to be slack space discoveries.")
-            self.files.append(obj)
+            self.files.append(value)
         else:
-            raise ValueError("Unexpected object type passed to PartitionObject.append(): %r." % type(obj))
-        self.child_objects.append(obj)
+            raise ValueError("Unexpected object type passed to PartitionObject.append(): %r." % type(value))
+        self.child_objects.append(value)
 
     def populate_from_Element(self, e):
         global _warned_elements

--- a/dfxml/objects.py
+++ b/dfxml/objects.py
@@ -282,7 +282,7 @@ class DFXMLObject(AbstractParentObject):
         """
         for co in self.child_objects:
             yield co
-            if hasattr(co, "child_objects"):
+            if isinstance(co, AbstractParentObject):
                 for gco in co:
                     yield gco
 
@@ -1456,7 +1456,7 @@ class DiskImageObject(AbstractParentObject, AbstractChildObject):
         """Recursively yields all child Objects in depth-first order."""
         for co in self.child_objects:
             yield co
-            if hasattr(co, "child_objects"):
+            if isinstance(co, AbstractParentObject):
                 for gco in co:
                     yield gco
 
@@ -1719,7 +1719,7 @@ class PartitionSystemObject(AbstractParentObject, AbstractChildObject):
         """Recursively yields all child Objects in depth-first order."""
         for co in self.child_objects:
             yield co
-            if hasattr(co, "child_objects"):
+            if isinstance(co, AbstractParentObject):
                 for gco in co:
                     yield gco
 
@@ -2017,7 +2017,7 @@ class PartitionObject(AbstractParentObject, AbstractChildObject):
         """Recursively yields all child Objects in depth-first order."""
         for co in self.child_objects:
             yield co
-            if hasattr(co, "child_objects"):
+            if isinstance(co, AbstractParentObject):
                 for gco in co:
                     yield gco
 
@@ -2325,7 +2325,7 @@ class VolumeObject(AbstractParentObject, AbstractChildObject):
         """Recursively yields all child Objects in depth-first order."""
         for co in self.child_objects:
             yield co
-            if hasattr(co, "child_objects"):
+            if isinstance(co, AbstractParentObject):
                 for gco in co:
                     yield gco
 

--- a/dfxml/objects.py
+++ b/dfxml/objects.py
@@ -847,7 +847,7 @@ class ByteRun(AbstractObject):
       "sha512"
     ])
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         self._has_hash_property = False
         for prop in ByteRun._all_properties:
             setattr(self, prop, kwargs.get(prop))
@@ -1402,16 +1402,16 @@ class DiskImageObject(AbstractObject):
       "volumes"
     ])
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         self.externals = kwargs.get("externals", OtherNSElementList())
 
         self._byte_runs : typing.Optional[ByteRuns] = None
-        self._child_objects = []
+        self._child_objects : typing.List[typing.Union[PartitionSystemObject, VolumeObject, FileObject]] = []
         self._error = None
-        self._files = []
-        self._partition_systems = []
+        self._files : typing.List[FileObject] = []
+        self._partition_systems : typing.List[PartitionSystemObject] = []
         self._sector_size = None
-        self._volumes = []
+        self._volumes : typing.List[VolumeObject] = []
 
     def __iter__(self):
         """Recursively yields all child Objects in depth-first order."""
@@ -1664,14 +1664,14 @@ class PartitionSystemObject(AbstractObject):
       "volume_name"
     ])
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         self.externals = kwargs.get("externals", OtherNSElementList())
 
         self._byte_runs : typing.Optional[ByteRuns] = None
-        self._child_objects = []
+        self._child_objects : typing.List[typing.Union[PartitionObject, FileObject]] = []
         self._error = None
-        self._files = []
-        self._partitions = []
+        self._files : typing.List[FileObject] = []
+        self._partitions : typing.List[PartitionObject] = []
         self._pstype_str = None
 
         #TODO Make @property methods once properties listed in DFXML schema.
@@ -1960,16 +1960,16 @@ class PartitionObject(AbstractObject):
       "volumes"
     ])
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         self.externals = kwargs.get("externals", OtherNSElementList())
 
         self._byte_runs : typing.Optional[ByteRuns] = None
-        self._child_objects = [] # For maintaining order of objects of different types.
-        self._files = []
+        self._child_objects : typing.List[typing.Union[PartitionSystemObject, PartitionObject, VolumeObject, FileObject]] = [] # For maintaining order of objects of different types.
+        self._files : typing.List[FileObject] = []
         self._partition_index = None
-        self._partition_systems = []
-        self._partitions = []
-        self._volumes = []
+        self._partition_systems : typing.List[PartitionSystemObject] = []
+        self._partitions : typing.List[PartitionObject] = []
+        self._volumes : typing.List[VolumeObject] = []
         self._ptype = None
         self._ptype_str = None
 
@@ -2270,14 +2270,14 @@ class VolumeObject(AbstractObject):
       "volumes"
     ])
 
-    def __init__(self, *args, **kwargs):
-        self._child_objects = []
-        self._disk_images = []
-        self._files = []
-        self._volumes = []
+    def __init__(self, *args, **kwargs) -> None:
+        self._child_objects : typing.List[typing.Union[DiskImageObject, FileObject, VolumeObject]] = []
+        self._disk_images : typing.List[DiskImageObject] = []
+        self._files : typing.List[FileObject] = []
+        self._volumes : typing.List[VolumeObject] = []
 
-        self._annos = set()
-        self._diffs = set()
+        self._annos : typing.Set[str] = set()
+        self._diffs : typing.Set[str] = set()
 
         for prop in VolumeObject._all_properties:
             if prop in {

--- a/dfxml/objects.py
+++ b/dfxml/objects.py
@@ -1401,7 +1401,7 @@ class DiskImageObject(AbstractObject):
     def __init__(self, *args, **kwargs):
         self.externals = kwargs.get("externals", OtherNSElementList())
 
-        self._byte_runs = None
+        self._byte_runs : typing.Optional[ByteRuns] = None
         self._child_objects = []
         self._error = None
         self._files = []
@@ -1595,7 +1595,7 @@ class DiskImageObject(AbstractObject):
     @property
     def byte_runs(
       self
-    ) -> ByteRuns:
+    ) -> typing.Optional[ByteRuns]:
         return self._byte_runs
 
     @byte_runs.setter
@@ -1661,7 +1661,7 @@ class PartitionSystemObject(AbstractObject):
     def __init__(self, *args, **kwargs):
         self.externals = kwargs.get("externals", OtherNSElementList())
 
-        self._byte_runs = None
+        self._byte_runs : typing.Optional[ByteRuns] = None
         self._child_objects = []
         self._error = None
         self._files = []
@@ -1876,7 +1876,7 @@ class PartitionSystemObject(AbstractObject):
     @property
     def byte_runs(
       self
-    ) -> ByteRuns:
+    ) -> typing.Optional[ByteRuns]:
         return self._byte_runs
 
     @byte_runs.setter
@@ -1955,7 +1955,7 @@ class PartitionObject(AbstractObject):
     def __init__(self, *args, **kwargs):
         self.externals = kwargs.get("externals", OtherNSElementList())
 
-        self._byte_runs = None
+        self._byte_runs : typing.Optional[ByteRuns] = None
         self._child_objects = [] # For maintaining order of objects of different types.
         self._files = []
         self._partition_index = None
@@ -2151,7 +2151,7 @@ class PartitionObject(AbstractObject):
     @property
     def byte_runs(
       self
-    ) -> ByteRuns:
+    ) -> typing.Optional[ByteRuns]:
         return self._byte_runs
 
     @byte_runs.setter

--- a/dfxml/objects.py
+++ b/dfxml/objects.py
@@ -5194,7 +5194,9 @@ def iterparse(
     if need_cleanup:
         fh.close()
 
-def parse(filename):
+def parse(
+  filename : str
+) -> DFXMLObject:
     """
     Returns a DFXMLObject populated from the contents of the (string) filename argument.
     Internally, this function uses iterparse().  One key operational difference is this function also appends child objects emitted by iterparse() to parent objects; iterparse() does not handle parent-child relationships.
@@ -5236,7 +5238,12 @@ def parse(filename):
                 raise NotImplementedError("parse:Unexpected object type with end-event: %r." % type(obj))
 
     #_logger.debug("len(object_stack) = %d." % len(object_stack))
-    if len(object_stack) > 0:
-        return object_stack[0]
-    else:
-        return None
+    if len(object_stack) == 0:
+        raise ValueError("Failed to parse DFXML data from file: %r." % filename)
+
+    bottom_object = object_stack[0]
+    if not isinstance(bottom_object, DFXMLObject):
+        # TODO - There might be use cases that call for .parse() to handle files that contain, say, only a <fileobject> as its root.  This is left for future work, as there might be complexities with the schema.
+        raise NotImplementedError("The parse() function expects to operate on files with a root element of <dfxml>.")
+
+    return bottom_object

--- a/dfxml/objects.py
+++ b/dfxml/objects.py
@@ -284,6 +284,7 @@ class DFXMLObject(AbstractObject):
             #_logger.debug("ET namespaces after registration: %r." % ET._namespace_map)
 
     def append(self, value) -> None:
+        _typecheck(value, (DiskImageObject, PartitionSystemObject, PartitionObject, VolumeObject, FileObject))
         if isinstance(value, DiskImageObject):
             self.disk_images.append(value)
         elif isinstance(value, PartitionSystemObject):
@@ -294,10 +295,6 @@ class DFXMLObject(AbstractObject):
             self.volumes.append(value)
         elif isinstance(value, FileObject):
             self.files.append(value)
-        else:
-            _logger.debug("value = %r" % value)
-            raise TypeError("Expecting a DiskImageObject, PartitionSystemObject, PartitionObject, VolumeObject, or a FileObject.  Got instead this type: %r." % type(value))
-
         self.child_objects.append(value)
 
     def iter_namespaces(self) -> typing.Iterator[typing.Tuple[str, str]]:
@@ -717,13 +714,11 @@ class RegXMLObject(AbstractObject):
         ET.register_namespace(prefix, url)
 
     def append(self, value) -> None:
+        _typecheck(value, (HiveObject, CellObject))
         if isinstance(value, HiveObject):
             self._hives.append(value)
         elif isinstance(value, CellObject):
             self._cells.append(value)
-        else:
-            _logger.debug("value = %r" % value)
-            raise TypeError("Expecting a HiveObject or a CellObject.  Got instead this type: %r." % type(value))
         self.child_objects.append(value)
 
     def print_regxml(self, output_fh=sys.stdout):
@@ -1434,14 +1429,13 @@ class DiskImageObject(AbstractObject):
         return "DiskImageObject(" + ", ".join(parts) + ")"
 
     def append(self, value) -> None:
+        _typecheck(value, (PartitionSystemObject, VolumeObject, FileObject))
         if isinstance(value, PartitionSystemObject):
             self.partition_systems.append(value)
         elif isinstance(value, VolumeObject):
             self.volumes.append(value)
         elif isinstance(value, FileObject):
             self.files.append(value)
-        else:
-            raise ValueError("Unexpected object type passed to DiskImageObject.append(): %r." % type(value))
         self.child_objects.append(value)
 
     def pop_poststream_elements(self, diskimage_element):
@@ -1700,14 +1694,13 @@ class PartitionSystemObject(AbstractObject):
         """
         Note that files appended directly to a PartitionSystemObject are expected to be slack space discoveries.  A warning is raised if an allocated file is appended.
         """
+        _typecheck(value, (PartitionObject, FileObject))
         if isinstance(value, PartitionObject):
             self.partitions.append(value)
         elif isinstance(value, FileObject):
             if value.is_allocated():
                 warnings.warn("A partition system has had an 'allocated' file appended directly to it.  This list of files is expected to be slack space discoveries.")
             self.files.append(value)
-        else:
-            raise ValueError("Unexpected object type passed to PartitionSystemObject.append(): %r." % type(value))
         self.child_objects.append(value)
 
     def populate_from_Element(self, e):
@@ -2002,6 +1995,7 @@ class PartitionObject(AbstractObject):
         """
         Note that files appended directly to a PartitionObject are expected to be slack space discoveries.  A warning is raised if an allocated file is appended.
         """
+        _typecheck(value, (PartitionSystemObject, PartitionObject, VolumeObject, FileObject))
         if isinstance(value, PartitionSystemObject):
             self.partition_systems.append(value)
         elif isinstance(value, PartitionObject):
@@ -2012,8 +2006,6 @@ class PartitionObject(AbstractObject):
             if value.is_allocated():
                 warnings.warn("A partition has had an 'allocated' file appended directly to it.  This list of files is expected to be slack space discoveries.")
             self.files.append(value)
-        else:
-            raise ValueError("Unexpected object type passed to PartitionObject.append(): %r." % type(value))
         self.child_objects.append(value)
 
     def populate_from_Element(self, e):
@@ -2311,6 +2303,7 @@ class VolumeObject(AbstractObject):
       self,
       value : typing.Union[DiskImageObject, FileObject, VolumeObject]
     ) -> None:
+        _typecheck(value, (DiskImageObject, FileObject, VolumeObject))
         if isinstance(value, DiskImageObject):
             self.disk_images.append(value)
         elif isinstance(value, VolumeObject):

--- a/dfxml/objects.py
+++ b/dfxml/objects.py
@@ -5217,7 +5217,7 @@ def parse(filename):
     Returns a DFXMLObject populated from the contents of the (string) filename argument.
     Internally, this function uses iterparse().  One key operational difference is this function also appends child objects emitted by iterparse() to parent objects; iterparse() does not handle parent-child relationships.
     """
-    object_stack = []
+    object_stack : typing.List[AbstractParentObject] = []
 
     for (event, obj) in iterparse(filename):
         #_logger.debug("(event, type(obj)) = %r." % ((event, type(obj)),))

--- a/dfxml/objects.py
+++ b/dfxml/objects.py
@@ -190,7 +190,9 @@ class AbstractObject(abc.ABC):
     """
     This class is an abstract superclass of all of the *Object classes defined in objects.py, from DFXMLObject through to ByteRun.  It is provided for type-system convenience, particularly with parsing functions.
     """
-    pass
+    def __init__(self, *args, **kwargs) -> None:
+        # Match signature of object.__init__().
+        super().__init__()
 
 
 class DFXMLObject(AbstractObject):
@@ -237,6 +239,8 @@ class DFXMLObject(AbstractObject):
         self.add_namespace("", dfxml.XMLNS_DFXML)
         self.add_namespace("dc", dfxml.XMLNS_DC)
         self.add_namespace("dfxmlext", XMLNS_DFXML_EXT)
+
+        super().__init__(*args, **kwargs)
 
     def __iter__(self):
         """
@@ -615,6 +619,8 @@ class LibraryObject(AbstractObject):
         if len(args) >= 2:
             self.version = args[1]
 
+        super().__init__(*args, **kwargs)
+
     def __eq__(self, other : object) -> bool:
         """
         This equality function tests the name and version values strictly.  For less-strict testing, like allowing matching on missing versions, use relaxed_eq.
@@ -704,6 +710,8 @@ class RegXMLObject(AbstractObject):
         # Add default namespaces.
         #TODO This will cause a problem when the Objects bindings are used for a DFXML document and RegXML document in the same program.
         self.add_namespace("", XMLNS_REGXML)
+
+        super().__init__(*args, **kwargs)
 
     def __iter__(self):
         """Yields all HiveObjects, recursively their CellObjects, and the CellObjects directly attached to this RegXMLObject, in that order."""
@@ -853,6 +861,8 @@ class ByteRun(AbstractObject):
         self._has_hash_property = False
         for prop in ByteRun._all_properties:
             setattr(self, prop, kwargs.get(prop))
+
+        super().__init__(*args, **kwargs)
 
     def __add__(self, other):
         """
@@ -1179,8 +1189,9 @@ class ByteRuns(AbstractObject):
     def __init__(
       self,
       run_list : typing.Optional[typing.List[ByteRun]] = None,
-      *,
-      facet : typing.Optional[str] = None
+      *args,
+      facet : typing.Optional[str] = None,
+      **kwargs
     ) -> None:
         self._facet = facet
         self._listdata : typing.List[ByteRun] = []
@@ -1188,6 +1199,8 @@ class ByteRuns(AbstractObject):
         if isinstance(run_list, list):
             for run in run_list:
                 self.append(run)
+
+        super().__init__(*args, **kwargs)
 
     def __delitem__(self, key):
         del self._listdata[key]
@@ -1414,6 +1427,8 @@ class DiskImageObject(AbstractObject):
         self._partition_systems : typing.List[PartitionSystemObject] = []
         self._sector_size = None
         self._volumes : typing.List[VolumeObject] = []
+
+        super().__init__(*args, **kwargs)
 
     def __iter__(self):
         """Recursively yields all child Objects in depth-first order."""
@@ -1680,6 +1695,8 @@ class PartitionSystemObject(AbstractObject):
         self.block_size = None
         self.guid = None
         self.volume_name = None # (This might only appear on Solaris disklabels that are directly nested in a partition.)
+
+        super().__init__(*args, **kwargs)
 
     def __iter__(self):
         """Recursively yields all child Objects in depth-first order."""
@@ -1982,6 +1999,8 @@ class PartitionObject(AbstractObject):
         self.guid = None
         self.partition_label = None
         self.partition_system_offset = None # Unit: bytes.  Offset within partition system.  Could also be byte_run/@ps_offset, if that were defined in the ByteRun class.
+
+        super().__init__(*args, **kwargs)
 
     def __iter__(self):
         """Recursively yields all child Objects in depth-first order."""
@@ -2294,6 +2313,8 @@ class VolumeObject(AbstractObject):
                 setattr(self, prop, kwargs.get(prop, OtherNSElementList()))
             else:
                 setattr(self, prop, kwargs.get(prop))
+
+        super().__init__(*args, **kwargs)
 
     def __iter__(self):
         """Recursively yields all child Objects in depth-first order."""
@@ -2777,6 +2798,8 @@ class HiveObject(AbstractObject):
                 continue
             setattr(self, prop, kwargs.get(prop))
 
+        super().__init__(*args, **kwargs)
+
     def __iter__(self):
         """Yields all CellObjects directly attached to this HiveObject."""
         for c in self._cells:
@@ -2934,6 +2957,8 @@ class TimestampObject(AbstractObject):
             raise ValueError("Unexpected arguments.  Whole args tuple: %r." % (args,))
 
         self._timestamp = None
+
+        super().__init__(*args, **kwargs)
 
     def __eq__(self, other : object) -> bool:
         # Check type.
@@ -3190,6 +3215,8 @@ class FileObject(AbstractObject):
                 setattr(self, prop, kwargs.get(prop))
         self._annos : typing.Set[str] = set()
         self._diffs : typing.Set[str] = set()
+
+        super().__init__(*args, **kwargs)
 
     def __eq__(self, other : object) -> bool:
         if other is None:
@@ -4218,6 +4245,8 @@ class CellObject(AbstractObject):
                 setattr(self, prop, kwargs.get(prop))
 
         self._diffs = set()
+
+        super().__init__(*args, **kwargs)
 
     def __eq__(self, other : object) -> bool:
         if other is None:

--- a/dfxml/objects.py
+++ b/dfxml/objects.py
@@ -174,7 +174,7 @@ def _strcast(
 
 def _typecheck(
   obj : object,
-  classinfo : typing.Union[type, typing.Tuple[type]]
+  classinfo : typing.Union[type, typing.Tuple[type, ...]]
 ) -> None:
     if not isinstance(obj, classinfo):
         _logger.info("obj = " + repr(obj))

--- a/dfxml/objects.py
+++ b/dfxml/objects.py
@@ -34,6 +34,7 @@ __version__ = "0.11.6"
 # * User testing.
 # * Compatibility with the DFXML schema, version >1.1.1.
 
+import abc
 import logging
 import re
 import copy
@@ -184,7 +185,8 @@ def _typecheck(
         else:
             raise TypeError("Expecting object to be of type %r." % classinfo)
 
-class AbstractObject(object):
+
+class AbstractObject(abc.ABC):
     """
     This class is an abstract superclass of all of the *Object classes defined in objects.py, from DFXMLObject through to ByteRun.  It is provided for type-system convenience, particularly with parsing functions.
     """

--- a/dfxml/objects.py
+++ b/dfxml/objects.py
@@ -283,7 +283,10 @@ class DFXMLObject(AbstractObject):
             ET.register_namespace(prefix, url)
             #_logger.debug("ET namespaces after registration: %r." % ET._namespace_map)
 
-    def append(self, value) -> None:
+    def append(
+      self,
+      value : typing.Union[DiskImageObject, PartitionSystemObject, PartitionObject, VolumeObject, FileObject]
+    ) -> None:
         _typecheck(value, (DiskImageObject, PartitionSystemObject, PartitionObject, VolumeObject, FileObject))
         if isinstance(value, DiskImageObject):
             self.disk_images.append(value)
@@ -713,7 +716,10 @@ class RegXMLObject(AbstractObject):
         self._namespaces[prefix] = url
         ET.register_namespace(prefix, url)
 
-    def append(self, value) -> None:
+    def append(
+      self,
+      value : typing.Union[HiveObject, CellObject]
+    ) -> None:
         _typecheck(value, (HiveObject, CellObject))
         if isinstance(value, HiveObject):
             self._hives.append(value)
@@ -1231,7 +1237,10 @@ class ByteRuns(AbstractObject):
         _typecheck(value, ByteRun)
         self._listdata[key] = value
 
-    def append(self, value) -> None:
+    def append(
+      self,
+      value : ByteRun
+    ) -> None:
         """
         Appends a ByteRun object to this container's list.
         """
@@ -1428,7 +1437,10 @@ class DiskImageObject(AbstractObject):
                 parts.append("%s=%s" % (prop, val))
         return "DiskImageObject(" + ", ".join(parts) + ")"
 
-    def append(self, value) -> None:
+    def append(
+      self,
+      value : typing.Union[PartitionSystemObject, VolumeObject, FileObject]
+    ) -> None:
         _typecheck(value, (PartitionSystemObject, VolumeObject, FileObject))
         if isinstance(value, PartitionSystemObject):
             self.partition_systems.append(value)
@@ -1690,7 +1702,10 @@ class PartitionSystemObject(AbstractObject):
                 parts.append("%s=%s" % (prop, val))
         return "PartitionSystemObject(" + ", ".join(parts) + ")"
 
-    def append(self, value) -> None:
+    def append(
+      self,
+      value : typing.Union[PartitionObject, FileObject]
+    ) -> None:
         """
         Note that files appended directly to a PartitionSystemObject are expected to be slack space discoveries.  A warning is raised if an allocated file is appended.
         """
@@ -1991,7 +2006,10 @@ class PartitionObject(AbstractObject):
                 parts.append("%s=%s" % (prop, val))
         return "PartitionObject(" + ", ".join(parts) + ")"
 
-    def append(self, value) -> None:
+    def append(
+      self,
+      value : typing.Union[PartitionSystemObject, PartitionObject, VolumeObject, FileObject]
+    ) -> None:
         """
         Note that files appended directly to a PartitionObject are expected to be slack space discoveries.  A warning is raised if an allocated file is appended.
         """
@@ -2762,7 +2780,10 @@ class HiveObject(AbstractObject):
         for c in self._cells:
             yield c
 
-    def append(self, value) -> None:
+    def append(
+      self,
+      value : CellObject
+    ) -> None:
         _typecheck(value, CellObject)
         self._cells.append(value)
 
@@ -4142,7 +4163,10 @@ class OtherNSElementList(list):
         OtherNSElementList._check_qname(value.tag)
         super(OtherNSElementList, self).__setitem__(idx, value)
 
-    def append(self, value) -> None:
+    def append(
+      self,
+      value : ET.Element
+    ) -> None:
         _typecheck(value, ET.Element)
         OtherNSElementList._check_qname(value.tag)
         super(OtherNSElementList, self).append(value)

--- a/dfxml/objects.py
+++ b/dfxml/objects.py
@@ -22,7 +22,7 @@ With this module, reading disk images or DFXML files is done with the parse or i
 # Further explanation is on PEPs 484 and 563, via: https://stackoverflow.com/a/33533514
 from __future__ import annotations
 
-__version__ = "0.11.6"
+__version__ = "0.12.0"
 
 # Revision Log
 # 2018-07-22 @simsong - removed calls to logging, since this module shouldn't create log files.

--- a/dfxml/objects.py
+++ b/dfxml/objects.py
@@ -190,12 +190,31 @@ class AbstractObject(abc.ABC):
     """
     This class is an abstract superclass of all of the *Object classes defined in objects.py, from DFXMLObject through to ByteRun.  It is provided for type-system convenience, particularly with parsing functions.
     """
+
     def __init__(self, *args, **kwargs) -> None:
         # Match signature of object.__init__().
         super().__init__()
 
 
-class DFXMLObject(AbstractObject):
+class AbstractChildObject(AbstractObject):
+    """
+    This abstract superclass represents Objects that can be contained in some parent layer, such as a file that can be in a file system.  It is designed to exclude the top "Document" object, DFXMLObject.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class AbstractParentObject(AbstractObject):
+    """
+    This abstract superclass represents "container" Objects, that is, objects that provide an append() method.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class DFXMLObject(AbstractParentObject):
 
     def __init__(self, *args, **kwargs) -> None:
         self.command_line = kwargs.get("command_line")
@@ -686,7 +705,7 @@ class LibraryObject(AbstractObject):
         self._version = _strcast(value)
 
 
-class RegXMLObject(AbstractObject):
+class RegXMLObject(AbstractParentObject):
 
     def __init__(self, *args, **kwargs):
         self.child_objects = kwargs.get("child_objects", [])
@@ -1404,7 +1423,7 @@ class ByteRuns(AbstractObject):
         self._facet = val
 
 
-class DiskImageObject(AbstractObject):
+class DiskImageObject(AbstractParentObject, AbstractChildObject):
 
     _all_properties = set([
       "byte_runs",
@@ -1666,7 +1685,7 @@ class DiskImageObject(AbstractObject):
         return self._volumes
 
 
-class PartitionSystemObject(AbstractObject):
+class PartitionSystemObject(AbstractParentObject, AbstractChildObject):
 
     _all_properties = set([
       "block_size",
@@ -1958,7 +1977,7 @@ class PartitionSystemObject(AbstractObject):
         self._pstype_str = _strcast(val)
 
 
-class PartitionObject(AbstractObject):
+class PartitionObject(AbstractParentObject, AbstractChildObject):
 
     _all_properties = set([
       "block_count",
@@ -2254,7 +2273,7 @@ class PartitionObject(AbstractObject):
         return self._volumes
 
 
-class VolumeObject(AbstractObject):
+class VolumeObject(AbstractParentObject, AbstractChildObject):
 
     _all_properties = set([
       "annos",
@@ -2766,7 +2785,7 @@ class VolumeObject(AbstractObject):
         return self._volumes
 
 
-class HiveObject(AbstractObject):
+class HiveObject(AbstractParentObject, AbstractChildObject):
 
     _all_properties = set([
       "annos",
@@ -3106,7 +3125,7 @@ class TimestampObject(AbstractObject):
         return self._timestamp
 
 
-class FileObject(AbstractObject):
+class FileObject(AbstractChildObject):
     """
     This class provides property accesses, an XML serializer (ElementTree-based), and a deserializer.
     The properties interface is NOT function calls, but simple accesses.  That is, the old _fileobject_ style:
@@ -4201,7 +4220,7 @@ class OtherNSElementList(list):
         super(OtherNSElementList, self).append(value)
 
 
-class CellObject(AbstractObject):
+class CellObject(AbstractChildObject):
 
     _all_properties = set([
       "alloc",

--- a/dfxml/tests/storage_layers_test.py
+++ b/dfxml/tests/storage_layers_test.py
@@ -19,6 +19,7 @@ import os
 import sys
 import hashlib
 import logging
+import typing
 
 import dfxml.objects as Objects
 
@@ -52,7 +53,12 @@ tmphash = hashlib.sha512()
 tmphash.update(TEST_BYTE_STRING_5)
 TEST_HASH_5 = tmphash.hexdigest()
 
-def _test_file_in_non_fs_levels_deep(include_disk_image, include_partition_system, include_partition, include_file_system):
+def _test_file_in_non_fs_levels_deep(
+  include_disk_image : bool,
+  include_partition_system : bool,
+  include_partition : bool,
+  include_file_system : bool
+) -> None:
     """
     This test follows a simple, vertical storage layer stack, but adds a file at each layer.
     """
@@ -65,7 +71,7 @@ def _test_file_in_non_fs_levels_deep(include_disk_image, include_partition_syste
     fobj_dobj.sha512 = TEST_HASH_1
     dobj.append(fobj_dobj)
 
-    appender_stack = [dobj]
+    appender_stack : typing.List[Objects.AbstractParentObject] = [dobj]
 
     if include_disk_image:
         # Add disk image to top-level document.
@@ -150,7 +156,7 @@ def _test_file_in_non_fs_levels_deep(include_disk_image, include_partition_syste
         raise
     os.remove(tmp_filename)
 
-def test_file_in_non_fs_levels_deep():
+def test_file_in_non_fs_levels_deep() -> None:
     for include_disk_image in [True, False]:
         for include_partition_system in [True, False]:
             for include_partition in [True, False]:
@@ -169,7 +175,12 @@ def test_file_in_non_fs_levels_deep():
                         _logger.debug("include_file_system = %r." % include_file_system)
                         raise
 
-def _test_file_in_non_fs_levels_flat(include_disk_image, include_partition_system, include_partition, include_file_system):
+def _test_file_in_non_fs_levels_flat(
+  include_disk_image : bool,
+  include_partition_system : bool,
+  include_partition : bool,
+  include_file_system : bool
+) -> None:
     """
     This test follows a simple, horizontal storage layer stack (every container attached to top document object), and adds a file for each container.
     """
@@ -253,7 +264,7 @@ def _test_file_in_non_fs_levels_flat(include_disk_image, include_partition_syste
         raise
     os.remove(tmp_filename)
 
-def test_file_in_non_fs_levels_flat():
+def test_file_in_non_fs_levels_flat() -> None:
     for include_disk_image in [True, False]:
         for include_partition_system in [True, False]:
             for include_partition in [True, False]:
@@ -272,7 +283,7 @@ def test_file_in_non_fs_levels_flat():
                         _logger.debug("include_file_system = %r." % include_file_system)
                         raise
 
-def test_solaris_ps_in_partition():
+def test_solaris_ps_in_partition() -> None:
     dobj = Objects.DFXMLObject(version="1.2.0")
 
     psobj_outer = Objects.PartitionSystemObject()
@@ -319,7 +330,7 @@ def test_solaris_ps_in_partition():
         raise
     os.remove(tmp_filename)
 
-def test_partition_in_partition():
+def test_partition_in_partition() -> None:
     #TODO Remove "+" on DFXML Schema 1.3.0 tracking.
     dobj = Objects.DFXMLObject(version="1.2.0+")
 
@@ -345,7 +356,7 @@ def test_partition_in_partition():
         raise
     os.remove(tmp_filename)
 
-def test_hfsplus_in_hfs():
+def test_hfsplus_in_hfs() -> None:
     dobj = Objects.DFXMLObject(version="1.2.0")
     vobj_outer = Objects.VolumeObject()
     vobj_outer.ftype_str = "hfs"
@@ -368,7 +379,7 @@ def test_hfsplus_in_hfs():
         raise
     os.remove(tmp_filename)
 
-def test_disk_image_in_file_system():
+def test_disk_image_in_file_system() -> None:
     dobj = Objects.DFXMLObject(version="1.2.0")
 
     vobj = Objects.VolumeObject()

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -83,8 +83,7 @@ check-mypy: \
 	    ../dfxml/bin/tests \
 	    ../dfxml/__init__.py \
 	    ../dfxml/objects.py \
-	    ../dfxml/tests \
-	    .
+	    ../dfxml/tests
 	@echo "INFO:tests/Makefile:mypy is currently run against a subset of the dfxml directory." >&2
 
 #TODO - Strict type-checking is another long-term goal, likewise eventually done against all of ../dfxml.
@@ -93,13 +92,10 @@ check-mypy-strict: \
 	source venv/bin/activate \
 	  && mypy \
 	    --strict \
+	    . \
 	    ../dfxml/bin/idifference2.py \
 	    ../dfxml/bin/make_differential_dfxml.py \
-	    ../dfxml/bin/walk_to_dfxml.py \
-	    test_objects.py \
-	    test_reads.py \
-	    test_version.py \
-	    walk_to_dfxml/test_walk_to_dfxml.py
+	    ../dfxml/bin/walk_to_dfxml.py
 
 clean:
 	@$(MAKE) \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -96,6 +96,7 @@ check-mypy-strict: \
 	    ../dfxml/bin/idifference2.py \
 	    ../dfxml/bin/make_differential_dfxml.py \
 	    ../dfxml/bin/walk_to_dfxml.py \
+	    test_objects.py \
 	    test_reads.py \
 	    test_version.py \
 	    walk_to_dfxml/test_walk_to_dfxml.py

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -96,6 +96,7 @@ check-mypy-strict: \
 	    ../dfxml/bin/idifference2.py \
 	    ../dfxml/bin/make_differential_dfxml.py \
 	    ../dfxml/bin/walk_to_dfxml.py \
+	    test_reads.py \
 	    test_version.py \
 	    walk_to_dfxml/test_walk_to_dfxml.py
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -95,7 +95,9 @@ check-mypy-strict: \
 	    --strict \
 	    ../dfxml/bin/idifference2.py \
 	    ../dfxml/bin/make_differential_dfxml.py \
-	    ../dfxml/bin/walk_to_dfxml.py
+	    ../dfxml/bin/walk_to_dfxml.py \
+	    test_version.py \
+	    walk_to_dfxml/test_walk_to_dfxml.py
 
 clean:
 	@$(MAKE) \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -95,7 +95,8 @@ check-mypy-strict: \
 	    . \
 	    ../dfxml/bin/idifference2.py \
 	    ../dfxml/bin/make_differential_dfxml.py \
-	    ../dfxml/bin/walk_to_dfxml.py
+	    ../dfxml/bin/walk_to_dfxml.py \
+	    ../dfxml/tests/storage_layers_test.py
 
 clean:
 	@$(MAKE) \

--- a/tests/make_differential_dfxml/test_differential_dfxml.py
+++ b/tests/make_differential_dfxml/test_differential_dfxml.py
@@ -52,24 +52,24 @@ def srcdir() -> str:
     return retval
 
 @pytest.fixture
-def top_srcdir(srcdir) -> str:
+def top_srcdir(srcdir : str) -> str:
     retval = os.path.join(srcdir, "..", "..")
     assert os.path.exists(os.path.join(retval, "LICENSE.md")), "Hard-coded knowledge of file in top_srcdir is no longer correct."
     return retval
 
 @pytest.fixture
-def samples_srcdir(top_srcdir):
+def samples_srcdir(top_srcdir : str) -> str:
     return os.path.join(top_srcdir, "samples")
 
 @pytest.fixture
-def ddo_01_from_cli(srcdir) -> Objects.DFXMLObject:
+def ddo_01_from_cli(srcdir : str) -> Objects.DFXMLObject:
     retval = Objects.parse(os.path.join(srcdir, "differential_dfxml_test_01.dfxml"))
     if not isinstance(retval, Objects.DFXMLObject):
         raise TypeError()
     return retval
 
 @pytest.fixture
-def ddo_01_from_module(samples_srcdir) -> Objects.DFXMLObject:
+def ddo_01_from_module(samples_srcdir : str) -> Objects.DFXMLObject:
     retval = dfxml.bin.make_differential_dfxml.make_differential_dfxml(
       os.path.join(samples_srcdir, "difference_test_0.xml"),
       os.path.join(samples_srcdir, "difference_test_1.xml")
@@ -79,7 +79,7 @@ def ddo_01_from_module(samples_srcdir) -> Objects.DFXMLObject:
     return retval
 
 @pytest.fixture
-def ddo_01_from_serialization_1(ddo_01_from_module) -> Objects.DFXMLObject:
+def ddo_01_from_serialization_1(ddo_01_from_module : Objects.DFXMLObject) -> Objects.DFXMLObject:
     filename = None
     with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".dfxml") as tmp_fh:
         filename = tmp_fh.name
@@ -91,7 +91,7 @@ def ddo_01_from_serialization_1(ddo_01_from_module) -> Objects.DFXMLObject:
     return retval
 
 @pytest.fixture
-def ddo_01_from_serialization_2(ddo_01_from_serialization_1) -> Objects.DFXMLObject:
+def ddo_01_from_serialization_2(ddo_01_from_serialization_1 : Objects.DFXMLObject) -> Objects.DFXMLObject:
     filename = None
     with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".dfxml") as tmp_fh:
         filename = tmp_fh.name
@@ -103,7 +103,7 @@ def ddo_01_from_serialization_2(ddo_01_from_serialization_1) -> Objects.DFXMLObj
     return retval
 
 @pytest.fixture
-def ddo_23_from_cli(srcdir) -> Objects.DFXMLObject:
+def ddo_23_from_cli(srcdir : str) -> Objects.DFXMLObject:
     retval = Objects.parse(os.path.join(srcdir, "differential_dfxml_test_23.dfxml"))
     if not isinstance(retval, Objects.DFXMLObject):
         raise TypeError()
@@ -111,7 +111,7 @@ def ddo_23_from_cli(srcdir) -> Objects.DFXMLObject:
     return retval
 
 @pytest.fixture
-def ddo_23_from_module(samples_srcdir) -> Objects.DFXMLObject:
+def ddo_23_from_module(samples_srcdir : str) -> Objects.DFXMLObject:
     retval = dfxml.bin.make_differential_dfxml.make_differential_dfxml(
       os.path.join(samples_srcdir, "difference_test_2.xml"),
       os.path.join(samples_srcdir, "difference_test_3.xml")
@@ -122,7 +122,7 @@ def ddo_23_from_module(samples_srcdir) -> Objects.DFXMLObject:
     return retval
 
 @pytest.fixture
-def ddo_23_from_serialization_1(ddo_23_from_module) -> typing.Generator[Objects.DFXMLObject, None, None]:
+def ddo_23_from_serialization_1(ddo_23_from_module : Objects.DFXMLObject) -> typing.Generator[Objects.DFXMLObject, None, None]:
     filename = None
     with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".dfxml") as tmp_fh:
         filename = tmp_fh.name
@@ -139,7 +139,7 @@ def ddo_23_from_serialization_1(ddo_23_from_module) -> typing.Generator[Objects.
     #os.unlink(filename)
 
 @pytest.fixture
-def ddo_23_from_serialization_2(ddo_23_from_serialization_1) -> typing.Generator[Objects.DFXMLObject, None, None]:
+def ddo_23_from_serialization_2(ddo_23_from_serialization_1 : Objects.DFXMLObject) -> typing.Generator[Objects.DFXMLObject, None, None]:
     filename = None
     with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".dfxml") as tmp_fh:
         filename = tmp_fh.name
@@ -155,7 +155,7 @@ def ddo_23_from_serialization_2(ddo_23_from_serialization_1) -> typing.Generator
 
 def _test_dfxml_object_01(
   dfxml_object : Objects.DFXMLObject
-):
+) -> None:
     expected_fileobject_diffs = {
       "i_am_new.txt": set([]),
       "i_will_be_deleted.txt": set([]),
@@ -190,7 +190,7 @@ def _test_dfxml_object_01(
 
 def _test_dfxml_object_23(
   dfxml_object : Objects.DFXMLObject
-):
+) -> None:
     expected_partition_annos = {
       (1048576, "FAT16"): {"deleted"},
       (1073741824, "FAT32"): set(),
@@ -208,26 +208,26 @@ def _test_dfxml_object_23(
             computed_partition_annos[(obj.partition_offset, obj.ftype_str)] = obj.annos or set()
     assert expected_partition_annos == computed_partition_annos
 
-def test_dfxml_object_01_from_cli(ddo_01_from_cli):
+def test_dfxml_object_01_from_cli(ddo_01_from_cli : Objects.DFXMLObject) -> None:
     _test_dfxml_object_01(ddo_01_from_cli)
 
-def test_dfxml_object_01_from_module(ddo_01_from_module):
+def test_dfxml_object_01_from_module(ddo_01_from_module : Objects.DFXMLObject) -> None:
     _test_dfxml_object_01(ddo_01_from_module)
 
-def test_dfxml_object_01_from_serialization_1(ddo_01_from_serialization_1):
+def test_dfxml_object_01_from_serialization_1(ddo_01_from_serialization_1 : Objects.DFXMLObject) -> None:
     _test_dfxml_object_01(ddo_01_from_serialization_1)
 
-def test_dfxml_object_01_from_serialization_2(ddo_01_from_serialization_2):
+def test_dfxml_object_01_from_serialization_2(ddo_01_from_serialization_2 : Objects.DFXMLObject) -> None:
     _test_dfxml_object_01(ddo_01_from_serialization_2)
 
-def test_dfxml_object_23_from_cli(ddo_23_from_cli):
+def test_dfxml_object_23_from_cli(ddo_23_from_cli : Objects.DFXMLObject) -> None:
     _test_dfxml_object_23(ddo_23_from_cli)
 
-def test_dfxml_object_23_from_module(ddo_23_from_module):
+def test_dfxml_object_23_from_module(ddo_23_from_module : Objects.DFXMLObject) -> None:
     _test_dfxml_object_23(ddo_23_from_module)
 
-def test_dfxml_object_23_from_serialization_1(ddo_23_from_serialization_1):
+def test_dfxml_object_23_from_serialization_1(ddo_23_from_serialization_1 : Objects.DFXMLObject) -> None:
     _test_dfxml_object_23(ddo_23_from_serialization_1)
 
-def test_dfxml_object_23_from_serialization_2(ddo_23_from_serialization_2):
+def test_dfxml_object_23_from_serialization_2(ddo_23_from_serialization_2 : Objects.DFXMLObject) -> None:
     _test_dfxml_object_23(ddo_23_from_serialization_2)

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -47,6 +47,8 @@ def test_AbstractHierarchyObject_append() -> None:
       Objects.VolumeObject,
       Objects.HiveObject
     ]
+    for parent_object_class in parent_object_classes:
+        assert issubclass(parent_object_class, Objects.AbstractParentObject)
 
     matrix_expected : typing.Dict[type, typing.Set[type]] = {
       Objects.DFXMLObject: {

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -57,3 +57,50 @@ def test_warn_append_allocated_file_to_psobj() -> None:
         psobj.append(fobj)
         assert len(w) == 1
         assert issubclass(w[-1].category, UserWarning) == 1
+
+def test_instance_isolation_byte_runs() -> None:
+    """
+    This test confirms no unintentional confusion of instance variables and class variables when initializing any abstract base classes.
+
+    Reference:
+    * https://docs.python.org/3/tutorial/classes.html#class-and-instance-variables
+    """
+    fobj1 = Objects.FileObject()
+    fobj2 = Objects.FileObject()
+
+    br1 = Objects.ByteRun(img_offset=1, len=2)
+    br2 = Objects.ByteRun(img_offset=3, len=4)
+
+    fobj1.byte_runs = Objects.ByteRuns()
+    fobj2.byte_runs = Objects.ByteRuns()
+
+    fobj1.byte_runs.append(br1)
+    fobj2.byte_runs.append(br2)
+
+    assert len(fobj1.byte_runs) == 1
+    assert len(fobj2.byte_runs) == 1
+
+def test_instance_isolation_child_objects() -> None:
+    """
+    This test confirms no unintentional confusion of instance variables and class variables when initializing any abstract base classes.
+
+    Reference:
+    * https://docs.python.org/3/tutorial/classes.html#class-and-instance-variables
+    """
+    diobj1 = Objects.DiskImageObject()
+    diobj2 = Objects.DiskImageObject()
+    fsobj1 = Objects.VolumeObject()
+
+    fobj1 = Objects.FileObject(filename="foo")
+    fobj2 = Objects.FileObject(filename="bar")
+    fobj3 = Objects.FileObject(filename="baz")
+    fobj4 = Objects.FileObject(filename="boo")
+
+    diobj1.append(fobj1)
+    diobj2.append(fobj2)
+    fsobj1.append(fobj3)
+    fsobj1.append(fobj4)
+
+    assert len(diobj1.child_objects) == 1
+    assert len(diobj2.child_objects) == 1
+    assert len(fsobj1.child_objects) == 2

--- a/tests/test_reads.py
+++ b/tests/test_reads.py
@@ -18,7 +18,7 @@ import pytest
 import dfxml
 import dfxml.objects
 
-def nop(x):
+def nop(x : object) -> None:
     pass
 
 @pytest.fixture
@@ -34,7 +34,7 @@ def difference_test_0_filepath(top_srcdir : str) -> str:
     assert os.path.exists(retval), "Hard-coded path to file did not find expected file, '${top_srcdir}/samples/difference_test_0.xml'."
     return retval
 
-def test_read_dfxml(difference_test_0_filepath):
+def test_read_dfxml(difference_test_0_filepath : str) -> None:
     """
     This test confirms that the DFXML pip-managed packaging exposes the dfxml package and the objects.py module.
     """

--- a/tests/test_reads.py
+++ b/tests/test_reads.py
@@ -29,7 +29,7 @@ def top_srcdir() -> str:
     return retval
 
 @pytest.fixture
-def difference_test_0_filepath(top_srcdir) -> str:
+def difference_test_0_filepath(top_srcdir : str) -> str:
     retval = os.path.join(top_srcdir, "samples", "difference_test_0.xml")
     assert os.path.exists(retval), "Hard-coded path to file did not find expected file, '${top_srcdir}/samples/difference_test_0.xml'."
     return retval
@@ -42,7 +42,7 @@ def test_read_dfxml(difference_test_0_filepath):
         dfxml.read_dfxml(fh, callback=nop)
 
 
-def test_objects_iterparse(difference_test_0_filepath):
+def test_objects_iterparse(difference_test_0_filepath : str) -> None:
     """
     This test confirms that the DFXML pip-managed packaging exposes the dfxml package's objects.py module.
     """

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -13,5 +13,5 @@
 
 import dfxml
 
-def test_version():
+def test_version() -> None:
     assert not dfxml.__version__ is None

--- a/tests/walk_to_dfxml/test_walk_to_dfxml.py
+++ b/tests/walk_to_dfxml/test_walk_to_dfxml.py
@@ -29,7 +29,7 @@ def srcdir() -> str:
     retval = os.path.dirname(__file__)
     return retval
 
-def test_walk_ignore_genprops(srcdir):
+def test_walk_ignore_genprops(srcdir : str) -> None:
     files_encountered = 0
     for (event, obj) in Objects.iterparse(os.path.join(srcdir, "walk_ignore_genprops.dfxml")):
         if not isinstance(obj, Objects.FileObject):
@@ -46,7 +46,7 @@ def test_walk_ignore_genprops(srcdir):
                 raise
     assert files_encountered > 0, "Encountered no files in walk_ignore_genprops.dfxml."
 
-def test_walk_ignore_hashes(srcdir):
+def test_walk_ignore_hashes(srcdir : str) -> None:
     files_encountered = 0
     for (event, obj) in Objects.iterparse(os.path.join(srcdir, "walk_ignore_hashes.dfxml")):
         if not isinstance(obj, Objects.FileObject):


### PR DESCRIPTION
In summary, this patch series was instigated by adding the `/tests` directory to the `mypy --strict` tests.  More concretely, the feature that truly received renewed type-safety attention was the `dfxml.objects.parse()` (`Objects.parse()`) function.

The total-parsing (versus iterative-parsing) procedure organizes the stream of `AbstractObject`s yielded by `dfxml.objects.iterparse()` into a parent-child hierarchy, using an object stack.  The hierarchy's root (`dfxml.objects.DFXMLObject`) and farthest potential leaf (`dfxml.objects.FileObject`) have slightly different behaviors, where all but the `FileObject` can be a "Container", or "Parent"; and all but the `DFXMLObject` can be a "Child".  Being able to designate parent versus child within the stack benefits other use cases that construct complex storage-layer hierarchies.  (This is also why the test script `dfxml/tests/storage_layers_test.py` was added to the strict type-check review.)

To make the `parse()` function's object stack type-safe (at least per `mypy --strict`), it was necessary to introduce two new abstract base classes into the `Object` hierarchy:

* `AbstractParentObject`
* `AbstractChildObject`

The classes designated `AbstractParentObject` in this patch series all were previously discoverable (à la duck typing) as behaving like parents by nature of having an `.append()` method, and/or having the `.child_objects` property.  `.child_objects` handling has been moved to `AbstractParentObject`, and to avoid instance-vs-class property errors [1] with another coming abstract class, `super()` is now used throughout the `Object` hierarchy [2].

[1] https://www.python.org/dev/peps/pep-0526/#class-and-instance-variable-annotations
[2] https://rhettinger.wordpress.com/2011/05/26/super-considered-super/

DISCLAIMER:
Participation by NIST in the creation of the documentation of mentioned software is not intended to imply a recommendation or endorsement by the National Institute of Standards and Technology, nor is it intended to imply that any specific software is necessarily the best available for the purpose.