### PR TITLE
Fix CI apt step and core Python class drift

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -31,7 +31,9 @@ jobs:
 
       - name:  Install xmllint on ubuntu
         if: runner.os == 'Linux'
-        run: sudo apt install libxml2-utils
+        run: |
+          sudo apt update
+          sudo apt install --yes libxml2-utils
 
       - name: Make check
         run: make check

--- a/dfxml/objects.py
+++ b/dfxml/objects.py
@@ -3490,8 +3490,9 @@ class FileObject(AbstractChildObject, AbstractGeometricObject):
                 self.ctime = s.st_ctime
 
         if not _should_ignore("crtime"):
-            if "st_birthtime" in dir(s):
-                self.crtime = s.st_birthtime
+            if sys.platform == "darwin":
+                if "st_birthtime" in dir(s):
+                    self.crtime = s.st_birthtime
 
     def to_Element(self):
         """Creates an ElementTree Element with elements in DFXML schema order."""


### PR DESCRIPTION
A recent development branch failed CI, because of a package being
unavailable.  According to Github documentation [1], the way to
alleviate this issue is to include `apt-get update` before trying to
install a package.

References:
[1] https://docs.github.com/en/actions/using-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-ubuntu-runners

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>