### PR TITLE
Use 'latest' options for current CI runner operating systems

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-20.04', 'macos-10.15']
+        os: ['ubuntu-latest', 'macos-latest']
         python-version: [3.8, 3.9]
     steps:
       - name: Checkout


### PR DESCRIPTION
The hard-coded reference to macos-10.15 now uses a deprecated runner.

This patch delegates picking the OS release to Github's `-latest` label.

References:
* https://github.com/actions/runner-images