### PR TITLE
Bump Python versions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,7 +8,7 @@ on: [push, pull_request]
 
 env:
   COVERAGE_OS: ubuntu-latest
-  COVERAGE_PYTHON_VERSION: 3.12
+  COVERAGE_PYTHON_VERSION: 3.13
 
 jobs:
   build:
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest']
-        python-version: ['3.8','3.12']
+        python-version: ['3.9','3.13']
 
     steps:
       - name: Checkout

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -28,8 +28,8 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.8'
-          - '3.12'
+          - '3.9'
+          - '3.13'
 
     steps:
     - uses: actions/checkout@v4

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ classifiers =
 [options]
 include_package_data = true
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.9
 
 # See CONTRIBUTE.md before adding a console script line.
 [options.entry_points]


### PR DESCRIPTION
Updating with the version changes from October, which include 3.13's release and 3.8's end-of-life.

No effects were observed on Make-managed files.

References:
* https://peps.python.org/pep-0569/
* https://peps.python.org/pep-0719/